### PR TITLE
受講生情報の更新フォームを作成し、アップデート処理を実装

### DIFF
--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -1,0 +1,95 @@
+package raisetech.student.management.controller;
+
+import java.util.List;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import raisetech.student.management.controller.converter.StudentConverter;
+import raisetech.student.management.model.data.Student;
+import raisetech.student.management.model.data.StudentCourse;
+import raisetech.student.management.model.domain.StudentDetail;
+import raisetech.student.management.model.services.StudentService;
+
+@Controller
+public class StudentController {
+
+  private final StudentService service;
+  private final StudentConverter converter;
+  private List<StudentDetail> studentsDetails; // コントローラーのフィールドとして空のstudentDetailを定義
+
+  public StudentController(StudentService service, StudentConverter converter) {
+    this.service = service;
+    this.converter = converter;
+  }
+
+  @GetMapping("/students")
+  public String getStudentList(Model model) {
+    List<Student> students = service.searchStudentList();
+    List<StudentCourse> studentsCourses = service.searchStudentsCourseList();
+    studentsDetails = converter.convertStudentDetails(students, studentsCourses); // フィールドに設定する
+
+    model.addAttribute("studentList", studentsDetails);
+    return "studentList";
+  }
+
+  @GetMapping("/students-courses")
+  public String getStudentCourseList(Model model) {
+    List<StudentCourse> studentsCourses = service.searchStudentsCourseList();
+
+    model.addAttribute("studentCourseList", studentsCourses);
+    return "studentCourseList"; // studentCourseList.htmlを指す。
+  }
+
+  @GetMapping("/students/new")
+  public String newStudent(Model model) {
+    model.addAttribute("studentDetail", new StudentDetail());
+    return "registerStudent";
+  }
+
+  @GetMapping("/students/update")
+  // 更新ボタンをクリックされたときのリンクに含まれる生徒のID情報を使ってstudentsDetailsから該当する生徒情報を取得し、その生徒情報に紐づく更新フォームを表示する
+  public String updateStudent(@RequestParam("id") Long id, Model model) {
+    StudentDetail studentDetail = studentsDetails.stream()
+        .filter(detail -> detail.getStudent().getId() == id)
+        .findFirst().orElse(null);
+
+    if (studentDetail != null) {
+      model.addAttribute("studentDetail", studentDetail);
+      return "updateStudent";
+    } else {
+      return "redirect:/students";
+    }
+  }
+
+  @PostMapping("/students/new")
+  // ビューの登録フォームで入力されたstudentDetailの情報をstudentServiceに送る
+  public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
+    if (result.hasErrors()) {
+      return "registerStudent";
+    }
+
+    // フォームで入力されたstudentDetailのstudentの情報とstudentCourseの情報（最初の一つ）をserviceにあるregisterStudentメソッドの引数とする
+    service.registerStudent(studentDetail);
+    return "redirect:/students";
+  }
+
+  @PostMapping("/students/update")
+  // ビューの更新フォームで入力されたstudentDetailの情報をstudentServiceに送る
+  public String updateStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result,
+      // name="_method"を指定して、PUTリクエストを受けとり、引数methodに入れる
+      @RequestParam(name = "_method", required = false) String method) {
+    if (result.hasErrors()) {
+      return "updateStudent";
+    }
+    // methodがPUTリクエストなら、service.updateStudentメソッドを実行する。
+    // フォームで更新されたstudentDetailをserviceにあるupdateStudentメソッドの引数とする
+    if ("PUT".equals(method)) {
+      service.updateStudent(studentDetail);
+    }
+    return "redirect:/students";
+  }
+}

--- a/src/main/java/raisetech/student/management/model/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/model/repository/StudentRepository.java
@@ -1,0 +1,57 @@
+package raisetech.student.management.model.repository;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+import raisetech.student.management.model.data.Student;
+import raisetech.student.management.model.data.StudentCourse;
+
+/**
+ * 受講生および受講生コースの情報をDBから取得する。
+ */
+@Mapper
+public interface StudentRepository {
+
+  /**
+   * @return データベースから受講生の情報を全件取得する。
+   */
+  @Select("SELECT * FROM students")
+  List<Student> search();
+
+  /**
+   * @return データベースから受講生のコース情報を全件取得する。
+   */
+  @Select("SELECT * FROM students_courses")
+  List<StudentCourse> searchStudentsCourses();
+
+  /**
+   * @return 受講生の情報をデータベースに登録する。
+   */
+  @Insert("INSERT students values(#{id}, #{fullname}, #{furigana}, #{nickname}, #{mail}, #{address}, #{age}, #{gender}, #{remark}, #{isDeleted})")
+  // ↓SQLで自動生成されたidをStudentオブジェクトのidとして使用できるようにする。
+  @Options(useGeneratedKeys = true, keyProperty = "id")
+  void registerStudent(Student student);
+
+  /**
+   * @return 受講生コースの情報をデータベースに登録する。
+   */
+  @Insert("INSERT students_courses values(#{id}, #{studentId}, #{courseName}, #{startDate}, #{endDate})")
+  @Options(useGeneratedKeys = true, keyProperty = "id")
+  void registerStudentCourse(StudentCourse studentCourse);
+
+  /**
+   * @return 受講生の情報を更新する。
+   */
+  @Update("UPDATE students SET fullname=#{fullname}, furigana=#{furigana}, nickname=#{nickname}, mail=#{mail}, address=#{address}, age=#{age}, gender=#{gender}, remark=#{remark}, is_deleted=#{isDeleted} WHERE id=#{id}")
+  void updateStudent(Student student);
+
+  /**
+   * @return 受講生コースの情報を更新する。
+   */
+  //更新フォームで操作できるのはcourseNameのみなので、それだけをSETの対象にする。
+  @Update("UPDATE students_courses SET course_name=#{courseName} WHERE id=#{id}")
+  void updateStudentCourse(StudentCourse studentCourse);
+}

--- a/src/main/java/raisetech/student/management/model/services/StudentService.java
+++ b/src/main/java/raisetech/student/management/model/services/StudentService.java
@@ -1,0 +1,52 @@
+package raisetech.student.management.model.services;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import raisetech.student.management.model.data.Student;
+import raisetech.student.management.model.data.StudentCourse;
+import raisetech.student.management.model.domain.StudentDetail;
+import raisetech.student.management.model.repository.StudentRepository;
+
+@Service
+public class StudentService {
+
+  private final StudentRepository repository;
+
+  public StudentService(StudentRepository repository) {
+    this.repository = repository;
+  }
+
+  public List<Student> searchStudentList() {
+    return repository.search();
+  }
+
+  public List<StudentCourse> searchStudentsCourseList() {
+    return repository.searchStudentsCourses();
+  }
+
+  @Transactional //トランザクション管理のために必須
+  // StudentControllerから送られてきたstudentDetailオブジェクトの情報をrepositoryに送る。
+  public void registerStudent(StudentDetail studentDetail) {
+    repository.registerStudent(
+        studentDetail.getStudent()); //まずstudentの情報をrepositoryのregisterStudentメソッドで登録（SQLでstudentsテーブルにINSERT）
+    // この時点で、StudentServiceから流れてきたstudentCourseには、フォームで入力されたcourseName以外の情報が入っていない。
+    for (StudentCourse studentCourse : studentDetail.getStudentCourse()) {
+      //studentCourseにstudentIdの数値（＝stundentテーブルのid）をセット。外部キー制約があるため、これはstudentCourseをstudents_coursesにINSERTする前に行う必要がある。
+      studentCourse.setStudentId(studentDetail.getStudent().getId());
+      studentCourse.setStartDate(LocalDateTime.now()); //受講開始日時は、この瞬間のLocalDateTimeをセット
+      studentCourse.setEndDate(LocalDateTime.now().plusYears(1)); //受講終了日時は、受講開始日時の1年後をセット
+      repository.registerStudentCourse(
+          studentCourse); //studentCourseのすべての情報が出そろったら、repositoryのregisterStudentCourseメソッドで登録（SQLでstudents_coursesテーブルにINSERT）
+    }
+  }
+
+  @Transactional //トランザクション管理のために必須
+  public void updateStudent(StudentDetail studentDetail) {
+    repository.updateStudent(studentDetail.getStudent());
+    for (StudentCourse studentCourse : studentDetail.getStudentCourse()) {
+      repository.updateStudentCourse(studentCourse);
+    }
+  }
+}

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<!--名前空間の宣言。thを持つ属性をThymeleafの属性として認識させることができる-->
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生情報一覧</title>
+</head>
+<body>
+<h1>受講生一覧</h1>
+<table border="1">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>名前</th>
+    <th>ふりがな</th>
+    <th>ニックネーム</th>
+    <th>メールアドレス</th>
+    <th>住所</th>
+    <th>年齢</th>
+    <th>性別</th>
+    <th>受講コース</th>
+    <th>備考</th>
+    <th>更新</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="studentDetail : ${studentList}">
+    <!--  以下、タグ内のデフォルト値（山田太郎など）はプレースホルダ{fullnameなど}によって置き換えられる-->
+    <td th:text="${studentDetail.student.id}">1</td>
+    <td th:text="${studentDetail.student.fullname}">山田太郎</td>
+    <td th:text="${studentDetail.student.furigana}">やまだたろう</td>
+    <td th:text="${studentDetail.student.nickname}">やまちゃん</td>
+    <td th:text="${studentDetail.student.mail}">mailadress@example.com</td>
+    <td th:text="${studentDetail.student.address}">東京</td>
+    <td th:text="${studentDetail.student.age}">26</td>
+    <td th:text="${studentDetail.student.gender}">男性</td>
+    <td>
+      <span th:each="course, iterStat : ${studentDetail.studentCourse}">
+        <span th:text="${course.courseName}"></span>
+        <span th:if="${!iterStat.last}">,</span>
+      </span>
+    </td>
+    <td th:text="${studentDetail.student.remark}">特になし</td>
+    <td>
+      <a th:href="@{/students/update(id=${studentDetail.student.id})}"><p>更新</p></a>
+    </td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生更新フォーム</title>
+</head>
+<body>
+<h1>受講生更新フォーム</h1>
+<!-- HTMLフォームは、PUTを直接指定することができないのでPOSTで代用 -->
+<form th:action="@{/students/update}" th:object="${studentDetail}" method="post">
+  <!--隠しフィールドでPUTメソッドを指定　⇒　この情報を使って、サーバーサイドでPOSTリクエストをPUTに変換 -->
+  <input type="hidden" name="_method" value="PUT">
+  <!-- idをフォーム入力せずに既存のものと対応づけるため、ユーザーに見えない形で取得 -->
+  <input type="hidden" th:field="*{student.id}" th:value="*{student.id}"/>
+  <div>
+    <label for="fullname">氏名（必須）:</label>
+    <input type="text" id="fullname" th:field="*{student.fullname}" required/>
+  </div>
+  <div>
+    <label for="furigana">ふりがな（必須）:</label>
+    <input type="text" id="furigana" th:field="*{student.furigana}" required/>
+  </div>
+  <div>
+    <label for="nickname">ニックネーム（任意）:</label>
+    <input type="text" id="nickname" th:field="*{student.nickname}"/>
+  </div>
+  <div>
+    <label for="mail">メールアドレス（必須）:</label>
+    <input type="text" id="mail" th:field="*{student.mail}" required/>
+  </div>
+  <div>
+    <label for="address">住所（任意）:</label>
+    <input type="text" id="address" th:field="*{student.address}"/>
+  </div>
+  <div>
+    <label for="age">年齢（任意）:</label>
+    <input type="text" id="age" th:field="*{student.age}"/>
+  </div>
+  <div>
+    <label for="gender">性別（任意）:</label>
+    <input type="text" id="gender" th:field="*{student.gender}"/>
+  </div>
+  <div>
+    <label for="remark">備考（任意）:</label>
+    <input type="text" id="remark" th:field="*{student.remark}"/>
+  </div>
+  <div th:each="course, stat : *{studentCourse}">
+    <!-- idをフォーム入力せずに既存のものと対応づけるため、ユーザーに見えない形で取得 -->
+    <input type="hidden" th:field="*{studentCourse[__${stat.index}__].id}"
+           th:value="*{studentCourse[__${stat.index}__].id}"/>
+    <label for="courseName"
+           th:for="*{studentCourse[__${stat.index}__].courseName}">受講コース:</label>
+    <input type="text" id="courseName" th:id="*{studentCourse[__${stat.index}__].courseName}"
+           th:field="*{studentCourse[__${stat.index}__].courseName}"
+           required/>
+  </div>
+  <div>
+    <button type="submit">更新</button>
+  </div>
+</form>
+</body>
+</html>


### PR DESCRIPTION
**新カリキュラム第29回の課題を以下のとおり実施いたしましたので、ご確認をお願いいたします。**
***
## 概要
**◆受講生一覧ページに「更新」のハイパーリンクを追加しました。これをクリックすると受講生更新フォームに遷移します。**

**◆受講生更新フォームには現在の受講生情報が入力されており、これを新しい情報に書き換えて「更新」ボタンをクリックすると、受講生情報および受講生コース情報が更新される機能を実装しました。更新後は、自動的に受講生情報一覧が表示され、受講生の情報が更新されたことを確認することができます。**

**◆MySQLで事前に用意したデータテーブルは、以下の通りです**
1.students
<img src="https://github.com/YaraiM/JavaNewChapter29Assignment/assets/153747182/fd863991-a9ad-4d63-a282-c36027fbf962" width="100%">  

2.students_courses
  <img src="https://github.com/YaraiM/JavaNewChapter29Assignment/assets/153747182/156fc58a-54ef-4e9f-a95e-2e58377266f4" width="70%">

***
 
## 動作確認

**1. パスとして/studentsを指定すると、受講生一覧が表示されます。「更新」をクリックすると、その受講生の情報を更新するページに遷移します。**
![studentsページ](https://github.com/YaraiM/JavaNewChapter29Assignment/assets/153747182/1b486908-a69e-4a4b-8fd6-1a72ccba2cb3)  

**2. 表示された受講生更新フォームには既存の情報が表示されており、新しい情報に書き換えて、更新ボタンを押すと、受講生情報と受講生コース情報が更新されます。**  
<img src="https://github.com/YaraiM/JavaNewChapter29Assignment/assets/153747182/5298de81-b652-4814-9b4b-21b94e3c4a05" width="50%">  
<img src="https://github.com/YaraiM/JavaNewChapter29Assignment/assets/153747182/3ac78eb0-f05c-483f-b421-fd7c7a2cda62"  width="50%">  

**3. 更新が正常に完了すると、ブラウザに受講生一覧が表示されます。受講生情報が更新されていることが分かります。**
※IDはMySQLで主キーとしてオートインクリメントにより自動で付番しています。なお、IDが一部飛んでいますが、もともとここには動作確認中に入力した受講生情報が入っていました。このPRで動作を示す際には不要な情報であり、MySQL側でDELETE操作をして削除したため、数字が飛んでいます。主キーの数値を手動調整すると予期せぬ動作につながる恐れがあるため、数字をあえて飛んだ状態にしていることをご了承ください。

<img src="https://github.com/YaraiM/JavaNewChapter29Assignment/assets/153747182/a9f77a2b-1190-4931-892c-f06e211efd2a"  width="70%">    

**4. DBを確認すると、受講生情報、受講生コース情報ともに、正常に更新されていることが分かります。**
![更新後students](https://github.com/YaraiM/JavaNewChapter29Assignment/assets/153747182/53573a8e-8431-4161-8e80-0db5e8b94848)
<img src="https://github.com/YaraiM/JavaNewChapter29Assignment/assets/153747182/c0b67e8a-66fd-47b0-bbb6-2f825cf77d3c" width="70%">
